### PR TITLE
Specify locale for tolowercase/touppercase for turkish users.

### DIFF
--- a/shukaro/artifice/block/decorative/BlockBasaltSlab.java
+++ b/shukaro/artifice/block/decorative/BlockBasaltSlab.java
@@ -72,7 +72,7 @@ public class BlockBasaltSlab extends BlockHalfSlab
         meta = meta > 7 ? meta - 8 : meta;
         if (meta >= types.length)
             meta = 0;
-        return "tile.artifice.slab." + types[meta].toLowerCase();
+        return "tile.artifice.slab." + types[meta].toLowerCase(Locale.ENGLISH);
     }
     
     @Override

--- a/shukaro/artifice/block/decorative/BlockFlora.java
+++ b/shukaro/artifice/block/decorative/BlockFlora.java
@@ -44,7 +44,7 @@ public class BlockFlora extends BlockFlower
     public void registerIcons(IconRegister reg)
     {
         for (int i=0; i<ArtificeCore.flora.length; i++)
-            icons[i] = IconHandler.registerSingle(reg, ArtificeCore.flora[i].toLowerCase(), "flora");
+            icons[i] = IconHandler.registerSingle(reg, ArtificeCore.flora[i].toLowerCase(Locale.ENGLISH), "flora");
     }
     
     @Override

--- a/shukaro/artifice/block/decorative/BlockMarbleSlab.java
+++ b/shukaro/artifice/block/decorative/BlockMarbleSlab.java
@@ -72,7 +72,7 @@ public class BlockMarbleSlab extends BlockHalfSlab
         meta = meta > 7 ? meta - 8 : meta;
         if (meta >= types.length)
             meta = 0;
-        return "tile.artifice.slab." + types[meta].toLowerCase();
+        return "tile.artifice.slab." + types[meta].toLowerCase(Locale.ENGLISH);
     }
     
     @Override

--- a/shukaro/artifice/block/decorative/BlockStairsArtifice.java
+++ b/shukaro/artifice/block/decorative/BlockStairsArtifice.java
@@ -12,7 +12,7 @@ public class BlockStairsArtifice extends BlockStairs
         super(id, block, meta);
         setLightOpacity(0);
         setCreativeTab(ArtificeCreativeTab.main);
-        String name = block.getUnlocalizedName() + ".stairs." + ArtificeCore.rocks[meta].toLowerCase();
+        String name = block.getUnlocalizedName() + ".stairs." + ArtificeCore.rocks[meta].toLowerCase(Locale.ENGLISH);
         name = name.replace("tile.", "");
         setUnlocalizedName(name);
     }

--- a/shukaro/artifice/block/decorative/ItemBlockBasalt.java
+++ b/shukaro/artifice/block/decorative/ItemBlockBasalt.java
@@ -18,7 +18,7 @@ public class ItemBlockBasalt extends ItemBlockArtifice
         if (stack.getItemDamage() == 0)
             return Block.blocksList[stack.itemID].getUnlocalizedName();
         if (stack.getItemDamage() > ArtificeCore.rocks.length)
-        	return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.rocks[0].toLowerCase();
-        return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.rocks[stack.getItemDamage()].toLowerCase();
+        	return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.rocks[0].toLowerCase(Locale.ENGLISH);
+        return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.rocks[stack.getItemDamage()].toLowerCase(Locale.ENGLISH);
     }
 }

--- a/shukaro/artifice/block/decorative/ItemBlockFlora.java
+++ b/shukaro/artifice/block/decorative/ItemBlockFlora.java
@@ -36,7 +36,7 @@ public class ItemBlockFlora extends ItemBlockArtifice
     public String getUnlocalizedName(ItemStack stack)
     {
         if (stack.getItemDamage() > ArtificeCore.flora.length)
-            return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.flora[0].toLowerCase();
-        return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.flora[stack.getItemDamage()].toLowerCase();
+            return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.flora[0].toLowerCase(Locale.ENGLISH);
+        return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.flora[stack.getItemDamage()].toLowerCase(Locale.ENGLISH);
     }
 }

--- a/shukaro/artifice/block/decorative/ItemBlockMarble.java
+++ b/shukaro/artifice/block/decorative/ItemBlockMarble.java
@@ -18,7 +18,7 @@ public class ItemBlockMarble extends ItemBlockArtifice
         if (stack.getItemDamage() == 0)
             return Block.blocksList[stack.itemID].getUnlocalizedName();
         if (stack.getItemDamage() > ArtificeCore.rocks.length)
-        	return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.rocks[0].toLowerCase();
-        return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.rocks[stack.getItemDamage()].toLowerCase();
+        	return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.rocks[0].toLowerCase(Locale.ENGLISH);
+        return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.rocks[stack.getItemDamage()].toLowerCase(Locale.ENGLISH);
     }
 }

--- a/shukaro/artifice/block/frame/BlockFrameBase.java
+++ b/shukaro/artifice/block/frame/BlockFrameBase.java
@@ -34,7 +34,7 @@ public class BlockFrameBase extends BlockFrame
     public void registerIcons(IconRegister reg)
     {
         for (int i=0; i<ArtificeCore.tiers.length; i++)
-            icons[i] = IconHandler.registerSingle(reg, ArtificeCore.tiers[i].toLowerCase(), "frame");
+            icons[i] = IconHandler.registerSingle(reg, ArtificeCore.tiers[i].toLowerCase(Locale.ENGLISH), "frame");
     }
 
     @Override

--- a/shukaro/artifice/block/frame/BlockFrameScaffold.java
+++ b/shukaro/artifice/block/frame/BlockFrameScaffold.java
@@ -212,7 +212,7 @@ public class BlockFrameScaffold extends BlockFrame
     {
     	ArtificeConfig.registerConnectedTextures(reg);
         for (int i=0; i<ArtificeCore.tiers.length; i++)
-            sideIcons[i] = IconHandler.registerSingle(reg, ArtificeCore.tiers[i].toLowerCase(), "scaffold/sides");
+            sideIcons[i] = IconHandler.registerSingle(reg, ArtificeCore.tiers[i].toLowerCase(Locale.ENGLISH), "scaffold/sides");
     }
 
     @Override

--- a/shukaro/artifice/block/frame/ItemBlockFrame.java
+++ b/shukaro/artifice/block/frame/ItemBlockFrame.java
@@ -16,7 +16,7 @@ public class ItemBlockFrame extends ItemBlockArtifice
     public String getUnlocalizedName(ItemStack stack)
     {
     	if (stack.getItemDamage() > ArtificeCore.tiers.length)
-    		return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.tiers[0].toLowerCase();
-        return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.tiers[stack.getItemDamage()].toLowerCase();
+    		return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.tiers[0].toLowerCase(Locale.ENGLISH);
+        return Block.blocksList[stack.itemID].getUnlocalizedName() + "." + ArtificeCore.tiers[stack.getItemDamage()].toLowerCase(Locale.ENGLISH);
     }
 }

--- a/shukaro/artifice/item/ItemCoin.java
+++ b/shukaro/artifice/item/ItemCoin.java
@@ -43,7 +43,7 @@ public class ItemCoin extends Item
     {
         for (int i=0; i<coinTypes.length; i++)
         {
-            icons[i] = IconHandler.registerSingle(reg, coinTypes[i].toLowerCase(), "coin");
+            icons[i] = IconHandler.registerSingle(reg, coinTypes[i].toLowerCase(Locale.ENGLISH), "coin");
         }
     }
     

--- a/shukaro/artifice/item/ItemDye.java
+++ b/shukaro/artifice/item/ItemDye.java
@@ -45,7 +45,7 @@ public class ItemDye extends Item
     {
         for (int i=0; i<names.length; i++)
         {
-            icons[i] = IconHandler.registerSingle(reg, names[i].toLowerCase(), "dye");
+            icons[i] = IconHandler.registerSingle(reg, names[i].toLowerCase(Locale.ENGLISH), "dye");
         }
     }
     
@@ -60,7 +60,7 @@ public class ItemDye extends Item
     @Override
     public String getUnlocalizedName(ItemStack stack)
     {
-        return "item.artifice.dye." + names[stack.getItemDamage()].toLowerCase();
+        return "item.artifice.dye." + names[stack.getItemDamage()].toLowerCase(Locale.ENGLISH);
     }
     
     @Override

--- a/shukaro/artifice/item/ItemNugget.java
+++ b/shukaro/artifice/item/ItemNugget.java
@@ -43,7 +43,7 @@ public class ItemNugget extends Item
     {
         for (int i=0; i<nuggetTypes.length; i++)
         {
-            icons[i] = IconHandler.registerSingle(reg, nuggetTypes[i].toLowerCase(), "nugget");
+            icons[i] = IconHandler.registerSingle(reg, nuggetTypes[i].toLowerCase(Locale.ENGLISH), "nugget");
         }
     }
     
@@ -58,7 +58,7 @@ public class ItemNugget extends Item
     @Override
     public String getUnlocalizedName(ItemStack stack)
     {
-        return "item.artifice.nugget." + nuggetTypes[stack.getItemDamage()].toLowerCase();
+        return "item.artifice.nugget." + nuggetTypes[stack.getItemDamage()].toLowerCase(Locale.ENGLISH);
     }
     
     @Override

--- a/shukaro/artifice/item/ItemSickle.java
+++ b/shukaro/artifice/item/ItemSickle.java
@@ -31,7 +31,7 @@ public class ItemSickle extends ItemTool
         super(id, 3, mat, null);
         this.setCreativeTab(ArtificeCreativeTab.main);
         this.setMaxDamage(mat.getMaxUses()/2);
-        this.setUnlocalizedName("artifice.sickle." + this.toolMaterial.toString().toLowerCase());
+        this.setUnlocalizedName("artifice.sickle." + this.toolMaterial.toString().toLowerCase(Locale.ENGLISH));
         this.radius = getRadius(mat);
     }
     
@@ -83,7 +83,7 @@ public class ItemSickle extends ItemTool
     @SideOnly(Side.CLIENT)
     public void registerIcons(IconRegister reg)
     {
-        this.icon = IconHandler.registerSingle(reg, "sickle_" + this.toolMaterial.toString().toLowerCase(), "sickle");
+        this.icon = IconHandler.registerSingle(reg, "sickle_" + this.toolMaterial.toString().toLowerCase(Locale.ENGLISH), "sickle");
     }
     
     @Override

--- a/shukaro/artifice/item/ItemSledge.java
+++ b/shukaro/artifice/item/ItemSledge.java
@@ -32,7 +32,7 @@ public class ItemSledge extends ItemTool
         super(id, 2, mat, null);
         this.setCreativeTab(ArtificeCreativeTab.main);
         this.setMaxDamage(mat.getMaxUses()/4);
-        this.setUnlocalizedName("artifice.sledge." + this.toolMaterial.toString().toLowerCase());
+        this.setUnlocalizedName("artifice.sledge." + this.toolMaterial.toString().toLowerCase(Locale.ENGLISH));
         this.lossChance = getLossChance(mat);
     }
     
@@ -106,7 +106,7 @@ public class ItemSledge extends ItemTool
     @SideOnly(Side.CLIENT)
     public void registerIcons(IconRegister reg)
     {
-    	this.icon = IconHandler.registerSingle(reg, "sledge_" + this.toolMaterial.toString().toLowerCase(), "sledge");
+    	this.icon = IconHandler.registerSingle(reg, "sledge_" + this.toolMaterial.toString().toLowerCase(Locale.ENGLISH), "sledge");
     }
 
     @Override

--- a/shukaro/artifice/item/ItemSteel.java
+++ b/shukaro/artifice/item/ItemSteel.java
@@ -44,8 +44,8 @@ public class ItemSteel extends Item
     public String getUnlocalizedName(ItemStack stack)
     {
     	if (stack.getItemDamage() > 1)
-    		return "item.artifice.steel." + names[0].toLowerCase();
-        return "item.artifice.steel." + names[stack.getItemDamage()].toLowerCase();
+    		return "item.artifice.steel." + names[0].toLowerCase(Locale.ENGLISH);
+        return "item.artifice.steel." + names[stack.getItemDamage()].toLowerCase(Locale.ENGLISH);
     }
     
     @Override

--- a/shukaro/artifice/item/ItemUpgrade.java
+++ b/shukaro/artifice/item/ItemUpgrade.java
@@ -43,7 +43,7 @@ public class ItemUpgrade extends Item
     {
         for (int i=0; i<upgrades.length; i++)
         {
-            icons[i] = IconHandler.registerSingle(reg, upgrades[i].toLowerCase().replaceAll("\\s",""), "upgrade");
+            icons[i] = IconHandler.registerSingle(reg, upgrades[i].toLowerCase(Locale.ENGLISH).replaceAll("\\s",""), "upgrade");
         }
     }
     
@@ -58,7 +58,7 @@ public class ItemUpgrade extends Item
     @Override
     public String getUnlocalizedName(ItemStack stack)
     {
-        return "item.artifice.upgrade." + upgrades[stack.getItemDamage()].toLowerCase().replaceAll("\\s","");
+        return "item.artifice.upgrade." + upgrades[stack.getItemDamage()].toLowerCase(Locale.ENGLISH).replaceAll("\\s","");
     }
     
     @Override

--- a/shukaro/artifice/render/IconHandler.java
+++ b/shukaro/artifice/render/IconHandler.java
@@ -12,7 +12,7 @@ public class IconHandler
     {
         for (int i=0; i<texture.textureList.length; i++)
         {
-            texture.textureList[i] = reg.registerIcon(ArtificeCore.modID.toLowerCase() + ":" + folder + "/" + texture.name + "_" + (i > 9 ? i : "0" + i));
+            texture.textureList[i] = reg.registerIcon(ArtificeCore.modID.toLowerCase(Locale.ENGLISH) + ":" + folder + "/" + texture.name + "_" + (i > 9 ? i : "0" + i));
         }
     }
     
@@ -21,7 +21,7 @@ public class IconHandler
         Icon[] icons = new Icon[6];
         for (ForgeDirection d : ForgeDirection.VALID_DIRECTIONS)
         {
-            icons[d.ordinal()] = reg.registerIcon(ArtificeCore.modID.toLowerCase() + ":" + folder + "/" + name + "_" + d.toString().toLowerCase());
+            icons[d.ordinal()] = reg.registerIcon(ArtificeCore.modID.toLowerCase(Locale.ENGLISH) + ":" + folder + "/" + name + "_" + d.toString().toLowerCase(Locale.ENGLISH));
         }
         return icons;
     }
@@ -33,7 +33,7 @@ public class IconHandler
         {
             for (ForgeDirection d : ForgeDirection.VALID_DIRECTIONS)
             {
-                icons[i][d.ordinal()] = reg.registerIcon(ArtificeCore.modID.toLowerCase() + ":" + folder + "/" + names[i] + "_" + d.toString().toLowerCase());
+                icons[i][d.ordinal()] = reg.registerIcon(ArtificeCore.modID.toLowerCase(Locale.ENGLISH) + ":" + folder + "/" + names[i] + "_" + d.toString().toLowerCase(Locale.ENGLISH));
             }
         }
         return icons;
@@ -41,7 +41,7 @@ public class IconHandler
     
     public static Icon registerSingle(IconRegister reg, String name, String folder)
     {
-        Icon icon = reg.registerIcon(ArtificeCore.modID.toLowerCase() + ":" + folder + "/" + name);
+        Icon icon = reg.registerIcon(ArtificeCore.modID.toLowerCase(Locale.ENGLISH) + ":" + folder + "/" + name);
         return icon;
     }
     
@@ -50,7 +50,7 @@ public class IconHandler
         Icon[] icons = new Icon[names.length];
         for (int i=0; i<names.length; i++)
         {
-            icons[i] = reg.registerIcon(ArtificeCore.modID.toLowerCase() + ":" + folder + "/" + names[i]);
+            icons[i] = reg.registerIcon(ArtificeCore.modID.toLowerCase(Locale.ENGLISH) + ":" + folder + "/" + names[i]);
         }
         return icons;
     }


### PR DESCRIPTION
Addressing the following: http://mattryall.net/blog/2009/02/the-infamous-turkish-locale-bug

Turkish users have issues when tolower/toupper are used on things like unlocalized names with i's in them.
