### PR TITLE
Replace random rotation caching with hash function to stop memory leak.

### DIFF
--- a/src/main/java/shukaro/artifice/render/connectedtexture/CTMRenderer.java
+++ b/src/main/java/shukaro/artifice/render/connectedtexture/CTMRenderer.java
@@ -6,22 +6,13 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.world.IBlockAccess;
 import org.lwjgl.opengl.GL11;
 import shukaro.artifice.ArtificeConfig;
-import shukaro.artifice.block.decorative.BlockRockSlab;
 import shukaro.artifice.block.world.BlockRock;
 import shukaro.artifice.render.TextureHandler;
-import shukaro.artifice.util.BlockCoord;
 import shukaro.artifice.util.Drawing;
-
-import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class CTMRenderer implements ISimpleBlockRenderingHandler
 {
     RenderBlocksCTM rendererCTM = new RenderBlocksCTM();
-
-    private static Map<BlockCoord, Integer> degrees = new ConcurrentHashMap<BlockCoord, Integer>();
-    private static Random rand = new Random();
 
     @Override
     public void renderInventoryBlock(Block block, int metadata, int modelId, RenderBlocks renderer)
@@ -63,15 +54,9 @@ public class CTMRenderer implements ISimpleBlockRenderingHandler
 
             if (block instanceof BlockRock && world.getBlockMetadata(x, y, z) == 0)
             {
-                BlockCoord c = new BlockCoord(x, y, z);
-                int degree;
-                if (degrees.containsKey(c))
-                    degree = degrees.get(c);
-                else
-                {
-                    degree = rand.nextInt(4);
-                    degrees.put(c, degree);
-                }
+                long hash = (long)(x * 3129871) ^ (long)z * 116129781L ^ (long)y;
+                int degree = (int)(hash & 0x03);
+
                 rendererOld.uvRotateBottom = degree;
                 rendererOld.uvRotateEast = degree;
                 rendererOld.uvRotateNorth = degree;


### PR DESCRIPTION
See my comment on this issue: https://github.com/Shukaro/Artifice/issues/63

As users explore the world, the client caches millions of BlockCoord and HashTableEntry objects, resulting in devastating GC collections later on.  I've replaced the randomness with an "okay" hashing function.  There might be some room for improvement aesthetically, but it will stop the memory leak.
