### PR TITLE
Allow other mods to generate ores in Artifice rock

### DIFF
--- a/src/main/java/shukaro/artifice/block/world/BlockRock.java
+++ b/src/main/java/shukaro/artifice/block/world/BlockRock.java
@@ -134,4 +134,10 @@ public class BlockRock extends BlockArtifice
 
     @Override
     public int getRenderType() { return ArtificeConfig.ctmRenderID; }
+    
+    @Override
+	public boolean isReplaceableOreGen(World world, int x, int y, int z, Block target)
+	{
+		return target == this || target == Blocks.stone;
+	}
 }


### PR DESCRIPTION
Without this, Artifice rocks create large voids which contain far fewer ores, as most ores are coded to overwrite stone.
