### PR TITLE
Bug fix - missing return statement

### DIFF
--- a/src/main/java/shukaro/artifice/block/world/ItemBlockOre.java
+++ b/src/main/java/shukaro/artifice/block/world/ItemBlockOre.java
@@ -16,7 +16,7 @@ public class ItemBlockOre extends ItemBlockArtifice
     public String getUnlocalizedName(ItemStack stack)
     {
         if (stack.getItemDamage() >= ArtificeBlocks.rockBlockNames.length)
-            Block.getBlockFromItem(stack.getItem()).getUnlocalizedName();
+            return Block.getBlockFromItem(stack.getItem()).getUnlocalizedName();
         return Block.getBlockFromItem(stack.getItem()).getUnlocalizedName() + "." + ArtificeBlocks.rockBlockNames[stack.getItemDamage()];
     }
 }


### PR DESCRIPTION
Should fix Issue #91 - I didn’t test with minechem, but it fixes the
NEI crash with QMX’s modular power suit/numina version whose stack
trace starts with the same two lines. Looks to be a pretty simple
accidental commission of “return”